### PR TITLE
fix(blockfrost): encode additional UTxO scripts by detected Plutus version

### DIFF
--- a/blockfrost/additional_utxo_test.go
+++ b/blockfrost/additional_utxo_test.go
@@ -1,0 +1,328 @@
+package blockfrost
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Salvionied/apollo/serialization"
+	"github.com/Salvionied/apollo/serialization/Address"
+	"github.com/Salvionied/apollo/serialization/Asset"
+	"github.com/Salvionied/apollo/serialization/AssetName"
+	"github.com/Salvionied/apollo/serialization/MultiAsset"
+	"github.com/Salvionied/apollo/serialization/PlutusData"
+	"github.com/Salvionied/apollo/serialization/Policy"
+	"github.com/Salvionied/apollo/serialization/TransactionInput"
+	"github.com/Salvionied/apollo/serialization/TransactionOutput"
+	"github.com/Salvionied/apollo/serialization/UTxO"
+	"github.com/Salvionied/apollo/serialization/Value"
+	"github.com/Salvionied/cbor/v2"
+	"github.com/tj/assert"
+)
+
+const testAddr = "addr_test1wpgexmeunzsykesf42d4eqet5yvzeap6trjnflxqtkcf66g0kpnxt"
+
+// rawScriptBytes is an arbitrary but stable byte payload standing in for a
+// serialised Plutus script. The version key is what we assert on; the raw
+// bytes only need to round-trip unchanged (and crucially un-tagged).
+var rawScriptBytes = []byte{0x46, 0x01, 0x00, 0x00, 0x22, 0x00, 0x11}
+
+func buildUtxoWithScriptRef(
+	t *testing.T,
+	scriptRef *PlutusData.ScriptRef,
+) UTxO.UTxO {
+	t.Helper()
+
+	addr, err := Address.DecodeAddress(testAddr)
+	assert.NoError(t, err)
+
+	txId, _ := hex.DecodeString(
+		"0000000000000000000000000000000000000000000000000000000000000000",
+	)
+
+	out := TransactionOutput.TransactionOutput{
+		IsPostAlonzo: true,
+		PostAlonzo: TransactionOutput.TransactionOutputAlonzo{
+			Address:   addr,
+			Amount:    Value.Value{Coin: 2_000_000}.ToAlonzoValue(),
+			ScriptRef: scriptRef,
+		},
+	}
+
+	return UTxO.UTxO{
+		Input: TransactionInput.TransactionInput{
+			TransactionId: txId,
+			Index:         0,
+		},
+		Output: out,
+	}
+}
+
+func extractScriptRef(t *testing.T, item bfAdditionalUtxoItem) *bfScriptRef {
+	t.Helper()
+	out, ok := item[1].(bfTxOut)
+	assert.True(t, ok, "second element should be bfTxOut")
+	return out.ScriptRef
+}
+
+func TestBuildAdditionalUtxoItemPlutusV1(t *testing.T) {
+	ref, err := PlutusData.NewV1ScriptRef(PlutusData.PlutusV1Script(rawScriptBytes))
+	assert.NoError(t, err)
+
+	utxo := buildUtxoWithScriptRef(t, &ref)
+	item, err := buildAdditionalUtxoItem(utxo)
+	assert.NoError(t, err)
+
+	sr := extractScriptRef(t, item)
+	assert.NotNil(t, sr)
+	assert.NotNil(t, sr.PlutusV1)
+	assert.Nil(t, sr.PlutusV2)
+	assert.Nil(t, sr.PlutusV3)
+	assert.Equal(t, hex.EncodeToString(rawScriptBytes), *sr.PlutusV1)
+}
+
+func TestBuildAdditionalUtxoItemPlutusV2(t *testing.T) {
+	ref, err := PlutusData.NewV2ScriptRef(PlutusData.PlutusV2Script(rawScriptBytes))
+	assert.NoError(t, err)
+
+	utxo := buildUtxoWithScriptRef(t, &ref)
+	item, err := buildAdditionalUtxoItem(utxo)
+	assert.NoError(t, err)
+
+	sr := extractScriptRef(t, item)
+	assert.NotNil(t, sr)
+	assert.Nil(t, sr.PlutusV1)
+	assert.NotNil(t, sr.PlutusV2)
+	assert.Nil(t, sr.PlutusV3)
+	assert.Equal(t, hex.EncodeToString(rawScriptBytes), *sr.PlutusV2)
+}
+
+func TestBuildAdditionalUtxoItemPlutusV3(t *testing.T) {
+	ref, err := PlutusData.NewV3ScriptRef(PlutusData.PlutusV3Script(rawScriptBytes))
+	assert.NoError(t, err)
+
+	utxo := buildUtxoWithScriptRef(t, &ref)
+	item, err := buildAdditionalUtxoItem(utxo)
+	assert.NoError(t, err)
+
+	sr := extractScriptRef(t, item)
+	assert.NotNil(t, sr)
+	assert.Nil(t, sr.PlutusV1)
+	assert.Nil(t, sr.PlutusV2)
+	assert.NotNil(t, sr.PlutusV3)
+	assert.Equal(t, hex.EncodeToString(rawScriptBytes), *sr.PlutusV3)
+}
+
+// TestBuildAdditionalUtxoItemEmitsRawNotTagged guards against the old bug
+// where the whole tag-24-wrapped scriptRef CBOR was emitted instead of the
+// raw inner Plutus script bytes.
+func TestBuildAdditionalUtxoItemEmitsRawNotTagged(t *testing.T) {
+	ref, err := PlutusData.NewV3ScriptRef(PlutusData.PlutusV3Script(rawScriptBytes))
+	assert.NoError(t, err)
+
+	// What the buggy code used to emit: the CBOR marshal of the ScriptRef,
+	// i.e. tag 24 wrapping the inner [3, bytes].
+	taggedCbor, err := cbor.Marshal(&ref)
+	assert.NoError(t, err)
+	taggedHex := hex.EncodeToString(taggedCbor)
+
+	utxo := buildUtxoWithScriptRef(t, &ref)
+	item, err := buildAdditionalUtxoItem(utxo)
+	assert.NoError(t, err)
+
+	sr := extractScriptRef(t, item)
+	assert.NotNil(t, sr.PlutusV3)
+	assert.NotEqual(t, taggedHex, *sr.PlutusV3,
+		"must emit raw script bytes, not the tag-24 scriptRef envelope")
+	assert.Equal(t, hex.EncodeToString(rawScriptBytes), *sr.PlutusV3)
+}
+
+func TestBuildAdditionalUtxoItemNativeScriptUnsupported(t *testing.T) {
+	// Construct a real native script ref: inner CBOR is [0, native_script]
+	// where native_script is itself an array (a ScriptPubkey [0, keyHash]),
+	// NOT a byte string. This guards against decoding element 2 as []byte
+	// before checking the script type, which would surface a low-level CBOR
+	// type error instead of the clear "unsupported" error.
+	nativeScript := []interface{}{uint64(0), make([]byte, 28)}
+	inner, err := cbor.Marshal(
+		[]interface{}{uint64(scriptTypeNative), nativeScript},
+	)
+	assert.NoError(t, err)
+	ref := PlutusData.ScriptRef(inner)
+
+	utxo := buildUtxoWithScriptRef(t, &ref)
+	_, err = buildAdditionalUtxoItem(utxo)
+	assert.Error(t, err)
+	assert.True(t,
+		strings.Contains(err.Error(), "unsupported script type in additional UTxO set"),
+		"error should mention unsupported script type, got: %v", err,
+	)
+}
+
+func TestBuildAdditionalUtxoItemUnknownScriptTypeUnsupported(t *testing.T) {
+	// script_type 9 is not a valid Cardano script type.
+	inner, err := cbor.Marshal([]interface{}{uint64(9), rawScriptBytes})
+	assert.NoError(t, err)
+	ref := PlutusData.ScriptRef(inner)
+
+	utxo := buildUtxoWithScriptRef(t, &ref)
+	_, err = buildAdditionalUtxoItem(utxo)
+	assert.Error(t, err)
+	assert.True(t,
+		strings.Contains(err.Error(), "unsupported script type in additional UTxO set"),
+		"error should mention unsupported script type, got: %v", err,
+	)
+}
+
+func TestBuildAdditionalUtxoItemDatumHashCasing(t *testing.T) {
+	addr, err := Address.DecodeAddress(testAddr)
+	assert.NoError(t, err)
+
+	txId, _ := hex.DecodeString(
+		"1111111111111111111111111111111111111111111111111111111111111111",
+	)
+	datumHashBytes, _ := hex.DecodeString(
+		"923918e403bf43c34b4ef6b48eb2ee04babed17320d8d1b9ff9ad086e86f44ec",
+	)
+
+	out := TransactionOutput.TransactionOutput{
+		IsPostAlonzo: false,
+		PreAlonzo: TransactionOutput.TransactionOutputShelley{
+			Address:   addr,
+			Amount:    Value.Value{Coin: 2_000_000},
+			DatumHash: serialization.DatumHash{Payload: datumHashBytes},
+			HasDatum:  true,
+		},
+	}
+
+	utxo := UTxO.UTxO{
+		Input: TransactionInput.TransactionInput{
+			TransactionId: txId,
+			Index:         0,
+		},
+		Output: out,
+	}
+
+	item, err := buildAdditionalUtxoItem(utxo)
+	assert.NoError(t, err)
+
+	out2, ok := item[1].(bfTxOut)
+	assert.True(t, ok)
+	assert.NotNil(t, out2.DatumHash)
+	assert.Equal(t, hex.EncodeToString(datumHashBytes), *out2.DatumHash)
+
+	// Marshal the whole tx-out and assert the camelCase key is used (not
+	// the old snake_case "datum_hash"), and that the value/datum-hash shape
+	// matches the authoritative Ogmios v5 schema.
+	jsonBytes, err := json.Marshal(out2)
+	assert.NoError(t, err)
+	js := string(jsonBytes)
+	assert.True(t, strings.Contains(js, `"datumHash"`),
+		"expected camelCase datumHash key, got: %s", js)
+	assert.False(t, strings.Contains(js, `"datum_hash"`),
+		"should not contain snake_case datum_hash, got: %s", js)
+}
+
+// TestBuildAdditionalUtxoItemPostAlonzoHashDatum covers a post-Alonzo (Babbage)
+// output that carries a datum HASH (not an inline datum). GetDatumHash() is nil
+// for post-Alonzo outputs, so this exercises the DatumOption.DatumType switch
+// and must emit datumHash (and not datum).
+func TestBuildAdditionalUtxoItemPostAlonzoHashDatum(t *testing.T) {
+	addr, err := Address.DecodeAddress(testAddr)
+	assert.NoError(t, err)
+
+	txId, _ := hex.DecodeString(
+		"2222222222222222222222222222222222222222222222222222222222222222",
+	)
+	datumHashBytes, _ := hex.DecodeString(
+		"923918e403bf43c34b4ef6b48eb2ee04babed17320d8d1b9ff9ad086e86f44ec",
+	)
+
+	out := TransactionOutput.TransactionOutput{
+		IsPostAlonzo: true,
+		PostAlonzo: TransactionOutput.TransactionOutputAlonzo{
+			Address: addr,
+			Amount:  Value.Value{Coin: 2_000_000}.ToAlonzoValue(),
+			Datum: &PlutusData.DatumOption{
+				DatumType: PlutusData.DatumTypeHash,
+				Hash:      datumHashBytes,
+			},
+		},
+	}
+
+	utxo := UTxO.UTxO{
+		Input: TransactionInput.TransactionInput{
+			TransactionId: txId,
+			Index:         0,
+		},
+		Output: out,
+	}
+
+	item, err := buildAdditionalUtxoItem(utxo)
+	assert.NoError(t, err)
+
+	out2, ok := item[1].(bfTxOut)
+	assert.True(t, ok)
+	assert.NotNil(t, out2.DatumHash,
+		"post-Alonzo hash datum must emit datumHash")
+	assert.Equal(t, hex.EncodeToString(datumHashBytes), *out2.DatumHash)
+	assert.Nil(t, out2.Datum,
+		"datum and datumHash are mutually exclusive")
+
+	js, err := json.Marshal(out2)
+	assert.NoError(t, err)
+	assert.True(t, strings.Contains(string(js), `"datumHash"`),
+		"expected datumHash key, got: %s", string(js))
+}
+
+// TestBuildAdditionalUtxoItemValueShape guards the production-proven Ogmios v5
+// value encoding ({coins, assets:{<policy>.<assetNameHex>: qty}}) against
+// regression.
+func TestBuildAdditionalUtxoItemValueShape(t *testing.T) {
+	addr, err := Address.DecodeAddress(testAddr)
+	assert.NoError(t, err)
+
+	txId, _ := hex.DecodeString(
+		"3333333333333333333333333333333333333333333333333333333333333333",
+	)
+
+	policyHex := "00000000000000000000000000000000000000000000000000000001"
+	assetNameHex := "deadbeef"
+
+	val := Value.PureLovelaceValue(2_000_000)
+	an := AssetName.NewAssetNameFromHexString(assetNameHex)
+	ma := MultiAsset.MultiAsset[int64]{
+		Policy.PolicyId{Value: policyHex}: Asset.Asset[int64]{*an: 42},
+	}
+	val.AddAssets(ma)
+
+	out := TransactionOutput.TransactionOutput{
+		IsPostAlonzo: true,
+		PostAlonzo: TransactionOutput.TransactionOutputAlonzo{
+			Address: addr,
+			Amount:  val.ToAlonzoValue(),
+		},
+	}
+
+	utxo := UTxO.UTxO{
+		Input: TransactionInput.TransactionInput{
+			TransactionId: txId,
+			Index:         0,
+		},
+		Output: out,
+	}
+
+	item, err := buildAdditionalUtxoItem(utxo)
+	assert.NoError(t, err)
+
+	out2, ok := item[1].(bfTxOut)
+	assert.True(t, ok)
+	assert.Equal(t, int64(2_000_000), out2.Value.Coins)
+	assert.Equal(t, int64(42), out2.Value.Assets[policyHex+"."+assetNameHex])
+
+	js, err := json.Marshal(out2)
+	assert.NoError(t, err)
+	assert.True(t, strings.Contains(string(js), `"coins"`),
+		"expected coins key, got: %s", string(js))
+}

--- a/blockfrost/blockfrost.go
+++ b/blockfrost/blockfrost.go
@@ -681,6 +681,165 @@ func (b *BlockfrostProvider) doCustomSubmit(
 	return nil
 }
 
+// Cardano script_ref inner CBOR is [ script_type, script_bytes ] where
+// script_type: 0 = native, 1 = PlutusV1, 2 = PlutusV2, 3 = PlutusV3.
+const (
+	scriptTypeNative   = 0
+	scriptTypePlutusV1 = 1
+	scriptTypePlutusV2 = 2
+	scriptTypePlutusV3 = 3
+)
+
+// decodeScriptRef decodes apollo's PlutusData.ScriptRef into the script
+// language type and the RAW (un-tagged) serialised Plutus script bytes.
+//
+// apollo stores ScriptRef as the inner CBOR content of the script_ref wire
+// format (the bytes wrapped by CBOR tag 24, i.e. #6.24(bytes)); the tag-24
+// wrapper is only applied/stripped in ScriptRef.MarshalCBOR/UnmarshalCBOR.
+// That inner content is itself CBOR `[ script_type, script_bytes ]`, so we
+// decode it directly here.
+func decodeScriptRef(
+	scriptRef *PlutusData.ScriptRef,
+) (scriptType int, rawScript []byte, err error) {
+	if scriptRef == nil {
+		return 0, nil, errors.New("nil script ref")
+	}
+
+	// Decode the script type first and keep the script payload raw: only
+	// Plutus scripts carry a CBOR bytestring payload, whereas native scripts
+	// (type 0) carry a script array. Decoding the payload as a bytestring
+	// unconditionally would make a real native ref fail with a low-level CBOR
+	// type error instead of the caller's clear "unsupported" error.
+	var decoded struct {
+		_          struct{} `cbor:",toarray"`
+		ScriptType int
+		Script     cbor.RawMessage
+	}
+	if err := cbor.Unmarshal([]byte(*scriptRef), &decoded); err != nil {
+		return 0, nil, fmt.Errorf(
+			"failed to decode script ref CBOR: %w",
+			err,
+		)
+	}
+
+	switch decoded.ScriptType {
+	case scriptTypePlutusV1, scriptTypePlutusV2, scriptTypePlutusV3:
+		if err := cbor.Unmarshal(decoded.Script, &rawScript); err != nil {
+			return 0, nil, fmt.Errorf(
+				"failed to decode plutus script bytes: %w",
+				err,
+			)
+		}
+		return decoded.ScriptType, rawScript, nil
+	default:
+		// Native (type 0) or unknown: return the type with no bytes so the
+		// caller can emit a clear unsupported-script error.
+		return decoded.ScriptType, nil, nil
+	}
+}
+
+// buildAdditionalUtxoItem builds a single [txIn, txOut] additional-UTxO pair
+// for the Blockfrost (Ogmios v5) tx-evaluation endpoint.
+func buildAdditionalUtxoItem(
+	utxo UTxO.UTxO,
+) (bfAdditionalUtxoItem, error) {
+	txIn := bfTxIn{
+		TxId:  hex.EncodeToString(utxo.Input.TransactionId),
+		Index: utxo.Input.Index,
+	}
+
+	currentUtxoAmount := utxo.Output.GetAmount()
+	bfVal := bfValue{
+		Coins: currentUtxoAmount.GetCoin(),
+	}
+
+	if currentUtxoAmount.HasAssets {
+		assets := make(map[string]int64)
+		for policyId, assetMap := range currentUtxoAmount.Am.Value {
+			for assetName, quantity := range assetMap {
+				assetNameHex := assetName.HexString()
+				var unit string
+				if assetNameHex == "" {
+					unit = policyId.Value
+				} else {
+					unit = policyId.Value + "." + assetNameHex
+				}
+				assets[unit] = quantity
+			}
+		}
+		if len(assets) > 0 {
+			bfVal.Assets = assets
+		}
+	}
+
+	txOut := bfTxOut{
+		Address: utxo.Output.GetAddress().String(),
+		Value:   bfVal,
+	}
+
+	// Datum: pre-Alonzo outputs carry only a datum hash; post-Alonzo (Babbage)
+	// outputs carry either an inline datum or a datum hash. datum and datumHash
+	// are mutually exclusive.
+	if utxo.Output.IsPostAlonzo {
+		if d := utxo.Output.PostAlonzo.Datum; d != nil {
+			switch d.DatumType {
+			case PlutusData.DatumTypeInline:
+				if inlineDatum := utxo.Output.GetDatum(); inlineDatum != nil {
+					datumCbor, err := cbor.Marshal(inlineDatum)
+					if err != nil {
+						return bfAdditionalUtxoItem{}, fmt.Errorf(
+							"failed to encode inline datum in additional UTxO set: %w",
+							err,
+						)
+					}
+					datumHex := hex.EncodeToString(datumCbor)
+					txOut.Datum = &datumHex
+				}
+			case PlutusData.DatumTypeHash:
+				if len(d.Hash) > 0 {
+					datumHashHex := hex.EncodeToString(d.Hash)
+					txOut.DatumHash = &datumHashHex
+				}
+			}
+		}
+	} else if datumHash := utxo.Output.GetDatumHash(); datumHash != nil &&
+		len(datumHash.Payload) > 0 {
+		datumHashHex := hex.EncodeToString(datumHash.Payload)
+		txOut.DatumHash = &datumHashHex
+	}
+
+	if scriptRef := utxo.Output.GetScriptRef(); scriptRef != nil {
+		scriptType, rawScript, err := decodeScriptRef(scriptRef)
+		if err != nil {
+			return bfAdditionalUtxoItem{}, fmt.Errorf(
+				"failed to decode script ref in additional UTxO set: %w",
+				err,
+			)
+		}
+
+		rawScriptHex := hex.EncodeToString(rawScript)
+		switch scriptType {
+		case scriptTypePlutusV1:
+			txOut.ScriptRef = &bfScriptRef{PlutusV1: &rawScriptHex}
+		case scriptTypePlutusV2:
+			txOut.ScriptRef = &bfScriptRef{PlutusV2: &rawScriptHex}
+		case scriptTypePlutusV3:
+			txOut.ScriptRef = &bfScriptRef{PlutusV3: &rawScriptHex}
+		case scriptTypeNative:
+			return bfAdditionalUtxoItem{}, fmt.Errorf(
+				"unsupported script type in additional UTxO set: native scripts are not supported by the Ogmios v5 evaluation endpoint",
+			)
+		default:
+			return bfAdditionalUtxoItem{}, fmt.Errorf(
+				"unsupported script type in additional UTxO set: unknown script type %d",
+				scriptType,
+			)
+		}
+	}
+
+	return bfAdditionalUtxoItem{txIn, txOut}, nil
+}
+
 // EvaluateTx evaluates a transaction's scripts.
 func (b *BlockfrostProvider) EvaluateTx(
 	ctx context.Context,
@@ -689,73 +848,11 @@ func (b *BlockfrostProvider) EvaluateTx(
 ) (map[string]Redeemer.ExecutionUnits, error) {
 	additionalBfUtxos := make([]bfAdditionalUtxoItem, 0, len(additionalUTxOs))
 	for _, utxo := range additionalUTxOs {
-
-		txIn := bfTxIn{
-			TxId:  hex.EncodeToString(utxo.Input.TransactionId),
-			Index: utxo.Input.Index,
+		item, err := buildAdditionalUtxoItem(utxo)
+		if err != nil {
+			return nil, err
 		}
-
-		currentUtxoAmount := utxo.Output.GetAmount()
-		bfVal := bfValue{
-			Coins: currentUtxoAmount.GetCoin(),
-		}
-
-		if currentUtxoAmount.HasAssets {
-			assets := make(map[string]int64)
-			for policyId, assetMap := range currentUtxoAmount.Am.Value {
-				for assetName, quantity := range assetMap {
-					assetNameHex := assetName.HexString()
-					var unit string
-					if assetNameHex == "" {
-						unit = policyId.Value
-					} else {
-						unit = policyId.Value + "." + assetNameHex
-					}
-					assets[unit] = quantity
-				}
-			}
-			if len(assets) > 0 {
-				bfVal.Assets = assets
-			}
-		}
-
-		txOut := bfTxOut{
-			Address: utxo.Output.GetAddress().String(),
-			Value:   bfVal,
-		}
-
-		if datumHash := utxo.Output.GetDatumHash(); datumHash != nil &&
-			datumHash.Payload != nil &&
-			len(datumHash.Payload) > 0 {
-			datumHashHex := hex.EncodeToString(datumHash.Payload)
-			txOut.DatumHash = &datumHashHex
-		}
-
-		if utxo.Output.IsPostAlonzo && utxo.Output.PostAlonzo.Datum != nil {
-			if inlineDatum := utxo.Output.GetDatum(); inlineDatum != nil {
-				datumCbor, err := cbor.Marshal(inlineDatum)
-				if err == nil {
-					datumHex := hex.EncodeToString(datumCbor)
-					txOut.Datum = &datumHex
-				}
-			}
-		}
-
-		if scriptRef := utxo.Output.GetScriptRef(); scriptRef != nil {
-			scriptCbor, err := cbor.Marshal(scriptRef)
-			if err == nil {
-				scriptHex := hex.EncodeToString(scriptCbor)
-				// TODO dyanmically choose v1, v2, or v3
-				txOut.ScriptRef = &bfScriptRef{
-					PlutusV3: &scriptHex,
-				}
-			}
-		}
-
-		additionalBfUtxos = append(
-			additionalBfUtxos,
-			bfAdditionalUtxoItem{txIn, txOut},
-		)
+		additionalBfUtxos = append(additionalBfUtxos, item)
 	}
 
 	evalReq := bfEvalRequest{

--- a/blockfrost/blockfrost.go
+++ b/blockfrost/blockfrost.go
@@ -826,7 +826,7 @@ func buildAdditionalUtxoItem(
 		case scriptTypePlutusV3:
 			txOut.ScriptRef = &bfScriptRef{PlutusV3: &rawScriptHex}
 		case scriptTypeNative:
-			return bfAdditionalUtxoItem{}, fmt.Errorf(
+			return bfAdditionalUtxoItem{}, errors.New(
 				"unsupported script type in additional UTxO set: native scripts are not supported by the Ogmios v5 evaluation endpoint",
 			)
 		default:

--- a/blockfrost/types.go
+++ b/blockfrost/types.go
@@ -41,7 +41,7 @@ type bfScriptRef struct {
 type bfTxOut struct {
 	Address   string       `json:"address"`
 	Value     bfValue      `json:"value"` // Changed from Amount to Value
-	DatumHash *string      `json:"datum_hash,omitempty"`
+	DatumHash *string      `json:"datumHash,omitempty"`
 	Datum     *string      `json:"datum,omitempty"`
 	ScriptRef *bfScriptRef `json:"script,omitempty"`
 }


### PR DESCRIPTION
## Summary

The Blockfrost additional UTxO set sent to `/utils/txs/evaluate/utxos` hardcoded
`plutus:v3` for every reference script and emitted the tag-24 scriptRef envelope
instead of the raw script. This corrects the encoding:

- detect the Plutus language version (v1/v2/v3) from the script ref CBOR and emit
  the raw script under the correct `plutus:vN` key
- reject native and unknown script types with a clear error
- emit post-Alonzo datum hashes (previously dropped) and use the Ogmios v5
  `datumHash` key

The production-proven `{coins, assets}` value shape and inline datum encoding are
unchanged.

## Tests

New offline tests cover v1/v2/v3 detection, raw-not-tagged bytes, native and
unknown rejection, post-Alonzo hash datum, `datumHash` casing, and the
coins/assets value shape.
