### PR TITLE
fix(blockfrost): resolve reference script language from script hash

### DIFF
--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -129,7 +129,13 @@ func adaptBlockfrostAddressUTxOs(
 				if err != nil {
 					continue
 				}
-				scriptRefContent := PlutusData.ScriptRef(scriptCborBytes)
+				scriptRefContent, err := scriptRefFromHash(
+					bfUtxo.ReferenceScriptHash,
+					scriptCborBytes,
+				)
+				if err != nil {
+					continue
+				}
 				txOut.PostAlonzo.ScriptRef = &scriptRefContent
 			}
 		} else {
@@ -279,7 +285,16 @@ func adaptBlockfrostTxOutputToApolloUTxO(
 					err,
 				)
 			}
-			scriptRefContent := PlutusData.ScriptRef(scriptCborBytes)
+			scriptRefContent, err := scriptRefFromHash(
+				bfOut.ReferenceScriptHash,
+				scriptCborBytes,
+			)
+			if err != nil {
+				return UTxO.UTxO{}, fmt.Errorf(
+					"failed to build reference script ref: %w",
+					err,
+				)
+			}
 			output.PostAlonzo.ScriptRef = &scriptRefContent
 		}
 	} else {
@@ -417,4 +432,49 @@ func (p BlockfrostProtocolParameters) ToBaseParams() Base.ProtocolParameters {
 		MinFeeReferenceScriptsBase:       p.MinFeeReferenceScriptsBase,
 		MinFeeReferenceScriptsMultiplier: p.MinFeeReferenceScriptsMultiplier,
 	}
+}
+
+// scriptRefFromHash builds a typed apollo ScriptRef from a reference script's
+// CBOR by detecting its Plutus language version. It hashes the script as each
+// Plutus version and matches against the known reference script hash, which both
+// determines the language and validates the bytes. Native (timelock) scripts and
+// any script whose language cannot be determined fall back to the raw CBOR,
+// preserving prior behavior (apollo has no native ScriptRef constructor, and
+// native reference scripts are not used by the evaluation path).
+func scriptRefFromHash(
+	scriptHashHex string,
+	scriptCbor []byte,
+) (PlutusData.ScriptRef, error) {
+	hashBytes, err := hex.DecodeString(scriptHashHex)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"invalid reference script hash %q: %w",
+			scriptHashHex,
+			err,
+		)
+	}
+	var want serialization.ScriptHash
+	if len(hashBytes) != len(want) {
+		return nil, fmt.Errorf(
+			"invalid reference script hash length: expected %d bytes, got %d",
+			len(want),
+			len(hashBytes),
+		)
+	}
+	copy(want[:], hashBytes)
+
+	matches := func(h serialization.ScriptHash, err error) bool {
+		return err == nil && h == want
+	}
+
+	if v1 := PlutusData.PlutusV1Script(scriptCbor); matches(v1.Hash()) {
+		return PlutusData.NewV1ScriptRef(v1)
+	}
+	if v2 := PlutusData.PlutusV2Script(scriptCbor); matches(v2.Hash()) {
+		return PlutusData.NewV2ScriptRef(v2)
+	}
+	if v3 := PlutusData.PlutusV3Script(scriptCbor); matches(v3.Hash()) {
+		return PlutusData.NewV3ScriptRef(v3)
+	}
+	return PlutusData.ScriptRef(scriptCbor), nil
 }

--- a/blockfrost/script_ref_type_test.go
+++ b/blockfrost/script_ref_type_test.go
@@ -1,0 +1,91 @@
+package blockfrost
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/Salvionied/apollo/serialization"
+	"github.com/Salvionied/apollo/serialization/PlutusData"
+	"github.com/Salvionied/cbor/v2"
+	"github.com/tj/assert"
+	"github.com/zenGate-Global/cardano-connector-go/tests"
+)
+
+// decodeRefInner decodes a ScriptRef's inner [script_type, script_bytes] CBOR.
+func decodeRefInner(t *testing.T, ref PlutusData.ScriptRef) (int, []byte) {
+	t.Helper()
+	var decoded struct {
+		_          struct{} `cbor:",toarray"`
+		ScriptType int
+		Script     []byte
+	}
+	assert.NoError(t, cbor.Unmarshal([]byte(ref), &decoded))
+	return decoded.ScriptType, decoded.Script
+}
+
+// TestScriptRefFromHashDetectsPlutusVersion uses a real preprod reference script
+// (a Plutus V3 script) to confirm the language is detected by hash match and the
+// resulting ScriptRef is the typed [3, raw_script] form.
+func TestScriptRefFromHashDetectsPlutusVersion(t *testing.T) {
+	scriptCbor, err := hex.DecodeString(tests.ExpectedScriptCbor)
+	assert.NoError(t, err)
+
+	ref, err := scriptRefFromHash(tests.ScriptHashToQuery, scriptCbor)
+	assert.NoError(t, err)
+
+	scriptType, raw := decodeRefInner(t, ref)
+	assert.Equal(t, 3, scriptType, "expected PlutusV3 detection")
+	assert.Equal(t, scriptCbor, raw, "must wrap the raw script bytes unchanged")
+}
+
+// TestScriptRefFromHashFallsBackOnUnknownHash confirms that a script whose hash
+// matches no Plutus version (for example a native script) is preserved as the
+// raw CBOR rather than being mislabelled.
+func TestScriptRefFromHashFallsBackOnUnknownHash(t *testing.T) {
+	scriptCbor, err := hex.DecodeString(tests.ExpectedScriptCbor)
+	assert.NoError(t, err)
+
+	wrongHash := "00000000000000000000000000000000000000000000000000000000"
+	ref, err := scriptRefFromHash(wrongHash, scriptCbor)
+	assert.NoError(t, err)
+	assert.Equal(t, scriptCbor, []byte(ref),
+		"unmatched hash should fall back to the raw script bytes")
+}
+
+// TestScriptRefFromHashDetectsAllPlutusVersions checks v1/v2/v3 detection by
+// using each version's own computed hash, so the right language is selected and
+// the raw bytes are wrapped unchanged.
+func TestScriptRefFromHashDetectsAllPlutusVersions(t *testing.T) {
+	script := []byte{0x46, 0x01, 0x00, 0x00, 0x22, 0x00, 0x11}
+
+	v1h, err := PlutusData.PlutusV1Script(script).Hash()
+	assert.NoError(t, err)
+	v2h, err := PlutusData.PlutusV2Script(script).Hash()
+	assert.NoError(t, err)
+	v3h, err := PlutusData.PlutusV3Script(script).Hash()
+	assert.NoError(t, err)
+
+	for _, tc := range []struct {
+		name string
+		hash serialization.ScriptHash
+		want int
+	}{
+		{"v1", v1h, 1},
+		{"v2", v2h, 2},
+		{"v3", v3h, 3},
+	} {
+		ref, err := scriptRefFromHash(hex.EncodeToString(tc.hash.Bytes()), script)
+		assert.NoError(t, err, tc.name)
+		scriptType, raw := decodeRefInner(t, ref)
+		assert.Equal(t, tc.want, scriptType, tc.name)
+		assert.Equal(t, script, raw, tc.name)
+	}
+}
+
+func TestScriptRefFromHashRejectsInvalidHash(t *testing.T) {
+	_, err := scriptRefFromHash("not-hex", []byte{0x01})
+	assert.Error(t, err)
+
+	_, err = scriptRefFromHash("00", []byte{0x01})
+	assert.Error(t, err, "wrong-length hash should error")
+}


### PR DESCRIPTION
## Summary

When resolving a UTxO with a reference script, the Blockfrost adapter stored the
raw `/scripts/{hash}/cbor` bytes directly as `PlutusData.ScriptRef`, dropping the
Plutus language version. apollo's `ScriptRef` is the inner `[script_type,
script_bytes]` CBOR, so the stored ref was untyped and inconsistent with
`NewV1/V2/V3ScriptRef`.

This adds `scriptRefFromHash`, which detects the Plutus version by hashing the
script as v1/v2/v3 and matching the known `reference_script_hash` (this also
validates the bytes), then builds the proper typed `ScriptRef`. Native and
undeterminable scripts fall back to the raw CBOR (apollo has no native ScriptRef
constructor, and native reference scripts are not used by the evaluation path).
Both adapter call sites use it.

## Tests

Offline tests validate detection against a real preprod Plutus V3 reference
script, v1/v2/v3 detection via computed hashes, the raw fallback on hash
mismatch, and invalid-hash rejection.
