### PR TITLE
fix(plutigo): anchor local-eval slot-to-time at the Shelley boundary

### DIFF
--- a/plutigo/plutigo.go
+++ b/plutigo/plutigo.go
@@ -566,11 +566,56 @@ func (p *PlutigoProvider) resolveSlotState(ctx context.Context) (localSlotState,
 		)
 	}
 
+	// BlockFrost (and Ogmios genesis) report the *Byron* system start and a
+	// 1-second Shelley slot length. On networks with a Byron era (mainnet,
+	// preprod) the Byron era used 20-second slots, so an absolute slot number
+	// does NOT map linearly from the Byron genesis at 1s granularity: anchoring
+	// at (zeroSlot=0, zeroTime=ByronStart, slotLength=1s) shifts every converted
+	// time by the accumulated Byron offset (~18.5 days on preprod). Plutus
+	// validity-range bounds are derived from this conversion, so a script that
+	// compares the validity lower bound against a POSIX timestamp (e.g. an
+	// unlock time) then fails silently.
+	//
+	// The correct Plutus time anchor is the Shelley era boundary. The public
+	// Cardano networks are recognised by their well-known Byron system start, so
+	// map the reported start to the corresponding Shelley anchor (zeroSlot,
+	// zeroTime). Networks whose Byron start is not recognised (preview, private
+	// or custom networks) fall back to the legacy (genesis-derived) anchor,
+	// which is correct for Byron-less networks such as preview.
+	if anchor, ok := shelleySlotAnchor(int64(genesis.SystemStart)); ok {
+		return localSlotState{
+			zeroTime:   time.Unix(anchor.zeroTimeUnix, 0).UTC(),
+			zeroSlot:   anchor.zeroSlot,
+			slotLength: time.Duration(genesis.SlotLength) * time.Second,
+		}, nil
+	}
+
 	return localSlotState{
 		zeroTime:   time.Unix(int64(genesis.SystemStart), 0).UTC(),
 		zeroSlot:   0,
 		slotLength: time.Duration(genesis.SlotLength) * time.Second,
 	}, nil
+}
+
+type shelleyAnchor struct {
+	zeroSlot     uint64
+	zeroTimeUnix int64
+}
+
+// shelleySlotAnchor maps a network's Byron genesis system-start (as reported by
+// BlockFrost/Ogmios) to the absolute-slot/Unix-time anchor at which 1-second
+// Shelley slots begin. These are the canonical values used by off-chain
+// tooling (Lucid, Mesh, Ogmios) for slot<->time conversion. Returns ok=false
+// for networks that need no era adjustment (e.g. preview) or are unknown.
+func shelleySlotAnchor(byronSystemStartUnix int64) (shelleyAnchor, bool) {
+	switch byronSystemStartUnix {
+	case 1506203091: // mainnet Byron start; Shelley began at slot 4492800.
+		return shelleyAnchor{zeroSlot: 4492800, zeroTimeUnix: 1596059091}, true
+	case 1654041600: // preprod Byron start; Shelley began at slot 86400 / 1655769600.
+		return shelleyAnchor{zeroSlot: 86400, zeroTimeUnix: 1655769600}, true
+	default:
+		return shelleyAnchor{}, false
+	}
 }
 
 func (p *PlutigoProvider) resolveScript(

--- a/plutigo/slotstate_test.go
+++ b/plutigo/slotstate_test.go
@@ -1,0 +1,82 @@
+package plutigo
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Salvionied/apollo/v2/backend"
+)
+
+// TestResolveSlotStateAppliesShelleyAnchor verifies that the slot->time
+// conversion uses the Shelley era anchor for networks with a Byron era, rather
+// than naively anchoring absolute slot 0 at the Byron system start. Getting
+// this wrong shifts every converted time by the accumulated Byron offset (~18.5
+// days on preprod), which silently breaks any Plutus script that compares its
+// validity-range bound against a POSIX timestamp.
+func TestResolveSlotStateAppliesShelleyAnchor(t *testing.T) {
+	cases := []struct {
+		name             string
+		byronSystemStart int64
+		slot             uint64
+		// wantUnixMilli is the POSIX time (ms) the slot must convert to, matching
+		// the canonical off-chain slot<->time mapping used by the ledger/Ogmios.
+		wantUnixMilli int64
+	}{
+		{
+			// preprod: Shelley begins at slot 86400 anchored at 1655769600 (not
+			// the Byron system start 1654041600). Verified against a live preprod
+			// block: slot 126554038 == unix 1782237238.
+			name:             "preprod",
+			byronSystemStart: 1654041600,
+			slot:             126551926,
+			wantUnixMilli:    1782235126000,
+		},
+		{
+			// mainnet: Shelley began at slot 4492800 / 1596059091.
+			name:             "mainnet",
+			byronSystemStart: 1506203091,
+			slot:             4492800,
+			wantUnixMilli:    1596059091000,
+		},
+		{
+			// preview has no Byron era, so the legacy genesis-derived anchor
+			// (slot 0 at the system start) is already correct.
+			name:             "preview",
+			byronSystemStart: 1666656000,
+			slot:             100,
+			wantUnixMilli:    1666656100000,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			genesis := backend.GenesisParameters{
+				SystemStart: tc.byronSystemStart,
+				SlotLength:  1,
+			}
+			provider, err := New(Config{GenesisParamsOverride: &genesis})
+			if err != nil {
+				t.Fatalf("New failed: %v", err)
+			}
+			slotState, err := provider.resolveSlotState(context.Background())
+			if err != nil {
+				t.Fatalf("resolveSlotState failed: %v", err)
+			}
+			got, err := slotState.SlotToTime(tc.slot)
+			if err != nil {
+				t.Fatalf("SlotToTime failed: %v", err)
+			}
+			if got.UnixMilli() != tc.wantUnixMilli {
+				t.Fatalf(
+					"slot %d converted to %d ms (%s), want %d ms (%s)",
+					tc.slot,
+					got.UnixMilli(),
+					got.UTC(),
+					tc.wantUnixMilli,
+					time.UnixMilli(tc.wantUnixMilli).UTC(),
+				)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem
`resolveSlotState` anchored slot-to-time conversion at the Byron genesis system start (as reported by BlockFrost/Ogmios genesis) with a 1-second slot length. On networks with a Byron era (mainnet, preprod), Byron used 20-second slots, so anchoring absolute slot numbers at the Byron start with 1s granularity shifts every converted POSIX time by the accumulated Byron offset (~18.5 days on preprod).

Plutus validity-range bounds are derived from this conversion, so a script that compares the validity lower bound against a POSIX timestamp (e.g. an unlock/deadline check) saw incorrect bounds and failed silently under local plutigo evaluation.

## Fix
Map the well-known Byron system starts (mainnet, preprod) to their canonical Shelley-era-boundary anchors (the absolute-slot / Unix-time pair where 1-second Shelley slots begin), the same values used by Lucid/Mesh/Ogmios for slot<->time conversion. Networks without a Byron era (e.g. preview) or unknown networks keep the genesis-derived anchor.

## Tests
`plutigo/slotstate_test.go` covers the mainnet/preprod anchors and the preview/unknown fallback.

Validated on preprod: a reward-withdrawal tx evaluated locally via plutigo now produces validity bounds matching on-chain, and the withdrawal confirms.