### PR TITLE
fix(blockfrost): encode evaluate/utxos additional-utxo value as Ogmios v6

### DIFF
--- a/blockfrost/adapter.go
+++ b/blockfrost/adapter.go
@@ -236,25 +236,25 @@ func bfAdditionalUtxoItemFromUtxo(utxo common.Utxo) (bfAdditionalUtxoItem, error
 	if err != nil {
 		return bfAdditionalUtxoItem{}, fmt.Errorf("invalid lovelace amount: %w", err)
 	}
-	val := bfValue{Coins: coins}
+	// Ogmios-v6 value: lovelace under "ada", then one entry per policy id hex
+	// mapping asset name hex (empty string for the empty name) to quantity.
+	val := bfValue{"ada": {"lovelace": coins}}
 	if assets := out.Assets(); assets != nil {
-		assetMap := make(map[string]int64)
 		for _, policyId := range assets.Policies() {
 			policyHex := hex.EncodeToString(policyId.Bytes())
 			for _, assetName := range assets.Assets(policyId) {
-				key := policyHex
-				if len(assetName) > 0 {
-					key = policyHex + "." + hex.EncodeToString(assetName)
-				}
 				qty, err := bigIntToInt64(assets.Asset(policyId, assetName))
 				if err != nil {
-					return bfAdditionalUtxoItem{}, fmt.Errorf("invalid asset quantity for %s: %w", key, err)
+					return bfAdditionalUtxoItem{}, fmt.Errorf(
+						"invalid asset quantity for %s.%s: %w",
+						policyHex, hex.EncodeToString(assetName), err,
+					)
 				}
-				assetMap[key] = qty
+				if val[policyHex] == nil {
+					val[policyHex] = make(map[string]int64)
+				}
+				val[policyHex][hex.EncodeToString(assetName)] = qty
 			}
-		}
-		if len(assetMap) > 0 {
-			val.Assets = assetMap
 		}
 	}
 

--- a/blockfrost/additional_utxo_test.go
+++ b/blockfrost/additional_utxo_test.go
@@ -212,13 +212,18 @@ func TestBuildAdditionalUtxoItemValueShape(t *testing.T) {
 
 	out2, ok := item[1].(bfTxOut)
 	assert.True(t, ok)
-	assert.Equal(t, int64(2_000_000), out2.Value.Coins)
-	assert.Equal(t, int64(42), out2.Value.Assets[policyHex+"."+assetNameHex])
+	// Ogmios-v6 value: lovelace under "ada", assets nested under the policy id hex.
+	assert.Equal(t, int64(2_000_000), out2.Value["ada"]["lovelace"])
+	assert.Equal(t, int64(42), out2.Value[policyHex][assetNameHex])
 
 	js, err := json.Marshal(out2)
 	assert.NoError(t, err)
-	assert.True(t, strings.Contains(string(js), `"coins"`),
-		"expected coins key, got: %s", string(js))
+	assert.True(t, strings.Contains(string(js), `"ada":{"lovelace":2000000}`),
+		"expected ada/lovelace value, got: %s", string(js))
+	assert.False(t, strings.Contains(string(js), `"coins"`),
+		"v5 coins key must not appear, got: %s", string(js))
+	assert.False(t, strings.Contains(string(js), policyHex+"."+assetNameHex),
+		"v5 dotted asset key must not appear, got: %s", string(js))
 }
 
 func mustDecodeHexT(t *testing.T, s string) []byte {

--- a/blockfrost/types.go
+++ b/blockfrost/types.go
@@ -16,9 +16,13 @@ type BlockfrostProvider struct {
 
 // --- BlockFrost evaluate-with-utxos request types ---
 //
-// /utils/txs/evaluate/utxos proxies Ogmios, so the additionalUtxoSet uses the
-// Ogmios-v5 [txIn, txOut] schema. The value is {coins, assets}; a bare datum
-// hash is "datumHash"; reference scripts are
+// /utils/txs/evaluate/utxos proxies Ogmios. The additionalUtxoSet uses the
+// [txIn, txOut] pair schema, but the txOut value must be in the Ogmios-v6
+// shape: {"ada": {"lovelace": N}, "<policyHex>": {"<assetNameHex>": N}}. (The
+// older {coins, assets:{"policyHex.assetNameHex": N}} shape is rejected by the
+// proxy with "failed to decode payload from base64 or base16" because the
+// "policyHex.assetNameHex" key is not valid base16.) A bare datum hash is
+// "datumHash"; reference scripts are
 // {"plutus:v1"|"plutus:v2"|"plutus:v3"|"plutus:v4": "<base16 script>"}.
 
 type bfTxIn struct {
@@ -26,12 +30,10 @@ type bfTxIn struct {
 	Index int    `json:"index"`
 }
 
-type bfValue struct {
-	Coins int64 `json:"coins"`
-	// Assets key is the policy ID hex for the empty asset name, otherwise
-	// policyHex + "." + assetNameHex.
-	Assets map[string]int64 `json:"assets,omitempty"`
-}
+// bfValue is the Ogmios-v6 value object. The "ada" entry carries lovelace under
+// "lovelace"; every other entry is keyed by policy id hex and maps asset name
+// hex (empty string for the empty asset name) to quantity.
+type bfValue map[string]map[string]int64
 
 type bfScriptRef struct {
 	PlutusV1 *string `json:"plutus:v1,omitempty"`


### PR DESCRIPTION
## Summary

The BlockFrost `/utils/txs/evaluate/utxos` `additionalUtxoSet` path was unusable: every non-empty set was rejected by BlockFrost's Ogmios proxy with `Invalid request: failed to decode payload from base64 or base16`. (The bare `/utils/txs/evaluate` path with no additional UTxOs was unaffected, which is why on-chain-only evaluations worked.)

## Root cause

The txOut `value` was serialised in the Ogmios **v5** shape:
```json
{ "coins": 2000000, "assets": { "<policyHex>.<assetNameHex>": 1 } }
```
BlockFrost's proxy expects the Ogmios **v6** value shape, and tries to base16-decode the asset map keys — the `"<policyHex>.<assetNameHex>"` key (with the `.`) is not valid base16, so the whole request fails to decode.

## Fix

Encode the value in the Ogmios v6 shape, keeping the `[txIn, txOut]` pair structure:
```json
{ "ada": { "lovelace": 2000000 }, "<policyHex>": { "<assetNameHex>": 1 } }
```
(empty asset name → `""` key). `bfValue` becomes `map[string]map[string]int64`.

## Validation

- Verified against the **live preprod** endpoint: the v6 value is accepted (`jsonwsp/response`); the previous v5 value reproduces the `base64 or base16` fault.
- `TestBuildAdditionalUtxoItemValueShape` updated to assert the v6 JSON (`"ada":{"lovelace":...}`, nested policy map) and that the v5 `"coins"` key and dotted asset key no longer appear.
